### PR TITLE
Add LA Store and HealthNut Customer persona

### DIFF
--- a/jafgen/customers/customers.py
+++ b/jafgen/customers/customers.py
@@ -169,3 +169,22 @@ class Casuals(Customer):
         num_drinks = int(random.random() * 10 / 3)
         num_food = int(random.random() * 10 / 3)
         return Inventory.get_drink(num_drinks) + Inventory.get_food(num_food)
+
+
+class HealthNut(Customer):
+    "A light beverage in the sunshine as a treat"
+
+    def p_buy_persona(self, day):
+        if day.season == "summer":
+            buy_propensity = 0.1 + (self.favorite_number / 100) * 0.4
+            return buy_propensity
+        else:
+            return 0.2
+
+    def get_order_time(self, day):
+        avg_time = 5 * 60
+        order_time = np.random.normal(loc=avg_time, scale=120)
+        return max(0, int(order_time))
+
+    def get_order_items(self, day):
+        return Inventory.get_drink(1)

--- a/jafgen/customers/customers.py
+++ b/jafgen/customers/customers.py
@@ -1,5 +1,6 @@
 import random
 import uuid
+from typing import Any
 
 import numpy as np
 from faker import Faker
@@ -55,7 +56,7 @@ class Customer(object):
         else:
             return None
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.customer_id,
             "name": self.name,

--- a/jafgen/customers/customers.py
+++ b/jafgen/customers/customers.py
@@ -1,5 +1,6 @@
 import random
 import uuid
+from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
@@ -12,7 +13,7 @@ fake = Faker()
 Faker.seed(123456789)
 
 
-class Customer(object):
+class Customer(ABC):
     def __init__(self, store):
         self.customer_id = str(uuid.uuid4())
         self.store = store
@@ -38,12 +39,15 @@ class Customer(object):
 
         return Order(self, items, self.store, order_time)
 
+    @abstractmethod
     def get_order_items(self, day):
         raise NotImplementedError()
 
-    def get_order_time(self, store, day):
+    @abstractmethod
+    def get_order_time(self, day):
         raise NotImplementedError()
 
+    @abstractmethod
     def p_buy_persona(self, day):
         raise NotImplementedError()
 

--- a/jafgen/customers/order.py
+++ b/jafgen/customers/order.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from jafgen.customers.order_item import OrderItem
 
@@ -17,7 +18,7 @@ class Order(object):
     def __str__(self):
         return f"{self.customer.name} bought {str(self.items)} at {self.day}"
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.order_id,
             "customer": self.customer.customer_id,

--- a/jafgen/customers/order.py
+++ b/jafgen/customers/order.py
@@ -30,5 +30,5 @@ class Order(object):
             "order_total": int(self.order_total * 100),
         }
 
-    def items_to_dict(self):
-        return [i.to_dict(self.order_id) for i in self.items]
+    def items_to_dict(self) -> list[dict[str, Any]]:
+        return [item.to_dict() for item in self.items]

--- a/jafgen/customers/order_item.py
+++ b/jafgen/customers/order_item.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 
 class OrderItem(object):
@@ -7,7 +8,7 @@ class OrderItem(object):
         self.order_id = order_id
         self.item = item
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.item_id,
             "order_id": self.order_id,

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -5,6 +5,7 @@ import pandas as pd
 from rich.progress import track
 
 from jafgen.curves import Day
+from jafgen.stores.inventory import Inventory
 from jafgen.stores.market import Market
 from jafgen.stores.stock import Stock
 from jafgen.stores.store import Store
@@ -112,6 +113,7 @@ class Simulation(object):
 
     def save_results(self) -> None:
         stock: Stock = Stock()
+        inventory: Inventory = Inventory()
         entities: dict[str, pd.DataFrame] = {
             "customers": pd.DataFrame.from_records(
                 [customer.to_dict() for customer in self.customers.values()]
@@ -126,6 +128,7 @@ class Simulation(object):
                 [market.store.to_dict() for market in self.markets]
             ),
             "supplies": pd.DataFrame.from_records(stock.to_dict()),
+            "products": pd.DataFrame.from_records(inventory.to_dict()),
         }
         if not os.path.exists("./jaffle-data"):
             os.makedirs("./jaffle-data")

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -113,19 +113,19 @@ class Simulation(object):
     def save_results(self) -> None:
         stock: Stock = Stock()
         entities: dict[str, pd.DataFrame] = {
-            "customers": pd.DataFrame.from_dict(
-                (customer.to_dict() for customer in self.customers.values())
+            "customers": pd.DataFrame.from_records(
+                [customer.to_dict() for customer in self.customers.values()]
             ),
-            "orders": pd.DataFrame.from_dict(
-                (order.to_dict() for order in self.orders)
+            "orders": pd.DataFrame.from_records(
+                [order.to_dict() for order in self.orders]
             ),
-            "items": pd.DataFrame.from_dict(
-                (item.to_dict() for order in self.orders for item in order.items)
+            "items": pd.DataFrame.from_records(
+                [item.to_dict() for order in self.orders for item in order.items]
             ),
-            "stores": pd.DataFrame.from_dict(
-                (market.store.to_dict() for market in self.markets)
+            "stores": pd.DataFrame.from_records(
+                [market.store.to_dict() for market in self.markets]
             ),
-            "supplies": pd.DataFrame.from_dict(stock.to_dict()),
+            "supplies": pd.DataFrame.from_records(stock.to_dict()),
         }
         if not os.path.exists("./jaffle-data"):
             os.makedirs("./jaffle-data")

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -109,7 +109,7 @@ class Simulation(object):
                     if order.customer.customer_id not in self.customers:
                         self.customers[order.customer.customer_id] = order.customer
 
-    def save_results(self):
+    def save_results(self) -> None:
         stock: Stock = Stock()
         entities: dict[str, pd.DataFrame] = {
             "customers": pd.DataFrame.from_dict(

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -67,6 +67,7 @@ class Simulation(object):
             (str(uuid.uuid4()), "Chicago", 0.92, 605, 12 * self.scale, 0.0625),
             (str(uuid.uuid4()), "San Francisco", 0.87, 615, 11 * self.scale, 0.075),
             (str(uuid.uuid4()), "New Orleans", 0.92, 920, 8 * self.scale, 0.04),
+            (str(uuid.uuid4()), "Los Angeles", 0.87, 1107, 8 * self.scale, 0.08),
         ]
 
         self.markets = []

--- a/jafgen/stores/inventory.py
+++ b/jafgen/stores/inventory.py
@@ -24,7 +24,7 @@ class Inventory(object):
         return [random.choice(cls.inventory["beverage"]) for i in range(count)]
 
     @classmethod
-    def to_dict(cls):
+    def to_dict(cls) -> list[dict[str, Any]]:
         all_items = []
         for key in cls.inventory:
             all_items += [item.to_dict() for item in cls.inventory[key]]

--- a/jafgen/stores/item.py
+++ b/jafgen/stores/item.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class Item(object):
     def __init__(self, sku, name, description, type, price):
         self.sku = sku
@@ -12,7 +15,7 @@ class Item(object):
     def __repr__(self):
         return self.__str__()
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "sku": self.sku,
             "name": self.name,

--- a/jafgen/stores/market.py
+++ b/jafgen/stores/market.py
@@ -8,16 +8,18 @@ from jafgen.customers.customers import (
     Commuter,
     RemoteWorker,
     Student,
+    HealthNut,
 )
 
 
 class Market(object):
     PersonaMix = [
         (Commuter, 0.25),
-        (RemoteWorker, 0.2),
+        (RemoteWorker, 0.25),
         (BrunchCrowd, 0.1),
         (Student, 0.2),
-        (Casuals, 0.25),
+        (Casuals, 0.1),
+        (HealthNut, 0.1),
     ]
 
     def __init__(self, store, num_customers, days_to_penetration=365):
@@ -27,7 +29,7 @@ class Market(object):
 
         self.addressable_customers = []
 
-        for (Persona, weight) in self.PersonaMix:
+        for Persona, weight in self.PersonaMix:
             num_customers = int(weight * self.num_customers)
             for i in range(num_customers):
                 self.addressable_customers.append(Persona(store))

--- a/jafgen/stores/stock.py
+++ b/jafgen/stores/stock.py
@@ -16,7 +16,7 @@ class Stock(object):
                 cls.stock[sku].append(supply)
 
     @classmethod
-    def to_dict(cls):
+    def to_dict(cls) -> list[dict[str, Any]]:
         all_items = []
         for key in cls.stock:
             all_items += [item.to_dict(key) for item in cls.stock[key]]
@@ -74,7 +74,9 @@ Stock.update(
             perishable=False,
             skus=["BEV-001", "BEV-002", "BEV-003", "BEV-004", "BEV-005"],
         ),
-        Supply(id="SUP-008", name="chai mix", cost=0.98, perishable=True, skus=["BEV-002"]),
+        Supply(
+            id="SUP-008", name="chai mix", cost=0.98, perishable=True, skus=["BEV-002"]
+        ),
         Supply(
             id="SUP-009",
             name="bread",
@@ -89,9 +91,15 @@ Stock.update(
             perishable=True,
             skus=["JAF-002", "JAF-003", "JAF-004", "JAF-005"],
         ),
-        Supply(id="SUP-011", name="nutella", cost=0.46, perishable=True, skus=["JAF-001"]),
-        Supply(id="SUP-012", name="banana", cost=0.13, perishable=True, skus=["JAF-001"]),
-        Supply(id="SUP-013", name="beef stew", cost=1.69, perishable=True, skus=["JAF-002"]),
+        Supply(
+            id="SUP-011", name="nutella", cost=0.46, perishable=True, skus=["JAF-001"]
+        ),
+        Supply(
+            id="SUP-012", name="banana", cost=0.13, perishable=True, skus=["JAF-001"]
+        ),
+        Supply(
+            id="SUP-013", name="beef stew", cost=1.69, perishable=True, skus=["JAF-002"]
+        ),
         Supply(
             id="SUP-014",
             name="lamb and pork bratwurst",
@@ -106,23 +114,65 @@ Stock.update(
             perishable=True,
             skus=["JAF-003"],
         ),
-        Supply(id="SUP-016", name="mustard", cost=0.07, perishable=True, skus=["JAF-003"]),
-        Supply(id="SUP-017", name="pulled pork", cost=2.15, perishable=True, skus=["JAF-004"]),
-        Supply(id="SUP-018", name="pineapple", cost=0.26, perishable=True, skus=["JAF-004"]),
-        Supply(id="SUP-019", name="melon", cost=0.33, perishable=True, skus=["JAF-005"]),
-        Supply(id="SUP-020", name="minced beef", cost=1.24, perishable=True, skus=["JAF-005"]),
         Supply(
-            id="SUP-021", name="ghost pepper sauce", cost=0.2, perishable=True, skus=["JAF-004"]
-        ),
-        Supply(id="SUP-022", name="mango", cost=0.32, perishable=True, skus=["BEV-001"]),
-        Supply(id="SUP-023", name="tangerine", cost=0.2, perishable=True, skus=["BEV-001"]),
-        Supply(id="SUP-024", name="oatmilk", cost=0.11, perishable=True, skus=["BEV-002"]),
-        Supply(id="SUP-025", name="whey protein", cost=0.36, perishable=True, skus=["BEV-002"]),
-        Supply(
-            id="SUP-026", name="coffee", cost=0.52, perishable=True, skus=["BEV-003", "BEV-004"]
+            id="SUP-016", name="mustard", cost=0.07, perishable=True, skus=["JAF-003"]
         ),
         Supply(
-            id="SUP-027", name="french vanilla syrup", cost=0.72, perishable=True, skus=["BEV-003"]
+            id="SUP-017",
+            name="pulled pork",
+            cost=2.15,
+            perishable=True,
+            skus=["JAF-004"],
+        ),
+        Supply(
+            id="SUP-018", name="pineapple", cost=0.26, perishable=True, skus=["JAF-004"]
+        ),
+        Supply(
+            id="SUP-019", name="melon", cost=0.33, perishable=True, skus=["JAF-005"]
+        ),
+        Supply(
+            id="SUP-020",
+            name="minced beef",
+            cost=1.24,
+            perishable=True,
+            skus=["JAF-005"],
+        ),
+        Supply(
+            id="SUP-021",
+            name="ghost pepper sauce",
+            cost=0.2,
+            perishable=True,
+            skus=["JAF-004"],
+        ),
+        Supply(
+            id="SUP-022", name="mango", cost=0.32, perishable=True, skus=["BEV-001"]
+        ),
+        Supply(
+            id="SUP-023", name="tangerine", cost=0.2, perishable=True, skus=["BEV-001"]
+        ),
+        Supply(
+            id="SUP-024", name="oatmilk", cost=0.11, perishable=True, skus=["BEV-002"]
+        ),
+        Supply(
+            id="SUP-025",
+            name="whey protein",
+            cost=0.36,
+            perishable=True,
+            skus=["BEV-002"],
+        ),
+        Supply(
+            id="SUP-026",
+            name="coffee",
+            cost=0.52,
+            perishable=True,
+            skus=["BEV-003", "BEV-004"],
+        ),
+        Supply(
+            id="SUP-027",
+            name="french vanilla syrup",
+            cost=0.72,
+            perishable=True,
+            skus=["BEV-003"],
         ),
         Supply(id="SUP-028", name="kiwi", cost=0.2, perishable=True, skus=["BEV-005"]),
         Supply(id="SUP-029", name="lime", cost=0.13, perishable=True, skus=["BEV-005"]),

--- a/jafgen/stores/store.py
+++ b/jafgen/stores/store.py
@@ -1,5 +1,10 @@
+from typing import Any
+
+
 class Store(object):
-    def __init__(self, store_id, name, base_popularity, hours_of_operation, opened_date, tax_rate):
+    def __init__(
+        self, store_id, name, base_popularity, hours_of_operation, opened_date, tax_rate
+    ):
         self.store_id = store_id
         self.name = name
         self.base_popularity = base_popularity
@@ -32,7 +37,7 @@ class Store(object):
     def closes_at(self, date):
         return self.hours_of_operation.closes_at(date)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.store_id,
             "name": self.name,

--- a/jafgen/stores/supply.py
+++ b/jafgen/stores/supply.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class Supply(object):
     def __init__(self, id, name, cost, perishable, skus):
         self.id = id
@@ -12,7 +15,7 @@ class Supply(object):
     def __repr__(self):
         return self.__str__()
 
-    def to_dict(self, sku):
+    def to_dict(self, sku) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = true
+log_level = INFO

--- a/tests/test_order_totals.py
+++ b/tests/test_order_totals.py
@@ -6,7 +6,8 @@ from jafgen.stores.inventory import Inventory
 
 
 def test_order_totals():
-    """Ensure order totals are calculated correctly"""
+    """Ensure order totals are equivalent to the sum of the item prices and tax paid"""
+
     store = Store(str(1), "Testylvania", 0.85, 0, 9 * 100, 0.0659123)
     inventory = Inventory()
     orders = []

--- a/tests/test_order_totals.py
+++ b/tests/test_order_totals.py
@@ -1,0 +1,31 @@
+from jafgen.customers.order import Order
+from jafgen.curves import Day
+from jafgen.stores.store import Store
+from jafgen.customers.customers import RemoteWorker
+from jafgen.stores.inventory import Inventory
+
+
+def test_order_totals():
+    """Ensure order totals are calculated correctly"""
+    store = Store(str(1), "Testylvania", 0.85, 0, 9 * 100, 0.0659123)
+    inventory = Inventory()
+    orders = []
+    for i in range(1000):
+        orders.append(
+            Order(
+                customer=RemoteWorker(store=store),
+                items=[
+                    inventory.get_food()[0],
+                    inventory.get_drink()[0],
+                ],
+                store=store,
+                day=Day(date_index=i),
+            )
+        )
+    for order in orders:
+        assert order.subtotal == order.items[0].item.price + order.items[1].item.price
+        assert order.tax_paid == order.subtotal * order.store.tax_rate
+        assert order.order_total == order.subtotal + order.tax_paid
+        assert round(float(order.order_total), 2) == round(
+            float(order.subtotal), 2
+        ) + round(float(order.tax_paid), 2)


### PR DESCRIPTION
This PR does some minor refactoring, notably around the saving CSVs logic to use list comprehensions over generators to evaluate to a list of dicts and the `pd.from_records` method over `pd.from_dict` which _expects_ a list of dictionaries. The old way worked but made linters unhappy. There are now no more warnings from the linter with basic type checking on. (I expect there are _lots_ of warnings if you switch to strict, but I've implemented a bit more typing).

It also adds a test to ensure that order totals do indeed equal subtotal + tax_paid, there were some issues with this and rounding in the data before when building on this data in dbt. This should ensure that the source data is not the problem.

It also makes Customer into an ABC, which it is.

It also fixes #111

Lastly it adds a HealthNut persona who primarily buys beverages on summer mornings and an LA location.