### PR TITLE
Fix order total rounding errors in output

### DIFF
--- a/jafgen/customers/order.py
+++ b/jafgen/customers/order.py
@@ -23,11 +23,13 @@ class Order(object):
             "id": self.order_id,
             "customer": self.customer.customer_id,
             "ordered_at": self.day.date.isoformat(),
-            # "order_month": self.day.date.strftime("%Y-%m"),
             "store_id": self.store.store_id,
             "subtotal": int(self.subtotal * 100),
             "tax_paid": int(self.tax_paid * 100),
-            "order_total": int(self.order_total * 100),
+            # TODO: figure out why this is doesn't cause a test failure
+            # in tests/test_order_totals.py
+            # "order_total": int(self.order_total * 100),
+            "order_total": int(int(self.subtotal * 100) + int(self.tax_paid * 100)),
         }
 
     def items_to_dict(self) -> list[dict[str, Any]]:

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
 numpy
-pandas
 Faker
-typer[all]
+typer

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,22 @@
 #    uv pip compile requirements.in -o requirements.txt
 click==8.1.7
     # via typer
-faker==24.4.0
+faker==24.7.1
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 numpy==1.26.4
+pygments==2.17.2
+    # via rich
 python-dateutil==2.9.0.post0
     # via faker
+rich==13.7.1
+    # via typer
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via python-dateutil
-typer==0.10.0
-typing-extensions==4.10.0
+typer==0.12.2
+typing-extensions==4.11.0
     # via typer

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,32 +2,12 @@
 #    uv pip compile requirements.in -o requirements.txt
 click==8.1.7
     # via typer
-colorama==0.4.6
-    # via typer
 faker==24.4.0
-markdown-it-py==3.0.0
-    # via rich
-mdurl==0.1.2
-    # via markdown-it-py
 numpy==1.26.4
-    # via pandas
-pandas==2.2.1
-pygments==2.17.2
-    # via rich
 python-dateutil==2.9.0.post0
-    # via
-    #   faker
-    #   pandas
-pytz==2024.1
-    # via pandas
-rich==13.7.1
-    # via typer
-shellingham==1.5.4
-    # via typer
+    # via faker
 six==1.16.0
     # via python-dateutil
 typer==0.10.0
 typing-extensions==4.10.0
     # via typer
-tzdata==2024.1
-    # via pandas

--- a/tests/test_order_totals.py
+++ b/tests/test_order_totals.py
@@ -1,7 +1,7 @@
 from jafgen.customers.order import Order
 from jafgen.curves import Day
 from jafgen.stores.store import Store
-from jafgen.customers.customers import RemoteWorker
+from jafgen.customers.customers import RemoteWorker, BrunchCrowd, Student
 from jafgen.stores.inventory import Inventory
 
 
@@ -18,15 +18,49 @@ def test_order_totals():
                 items=[
                     inventory.get_food()[0],
                     inventory.get_drink()[0],
+                    inventory.get_food()[0],
+                ],
+                store=store,
+                day=Day(date_index=i),
+            )
+        )
+        orders.append(
+            Order(
+                customer=BrunchCrowd(store=store),
+                items=[
+                    inventory.get_food()[0],
+                    inventory.get_drink()[0],
+                    inventory.get_food()[0],
+                ],
+                store=store,
+                day=Day(date_index=i),
+            )
+        )
+        orders.append(
+            Order(
+                customer=Student(store=store),
+                items=[
+                    inventory.get_food()[0],
+                    inventory.get_drink()[0],
+                    inventory.get_food()[0],
                 ],
                 store=store,
                 day=Day(date_index=i),
             )
         )
     for order in orders:
-        assert order.subtotal == order.items[0].item.price + order.items[1].item.price
+        assert (
+            order.subtotal
+            == order.items[0].item.price
+            + order.items[1].item.price
+            + order.items[2].item.price
+        )
         assert order.tax_paid == order.subtotal * order.store.tax_rate
         assert order.order_total == order.subtotal + order.tax_paid
         assert round(float(order.order_total), 2) == round(
             float(order.subtotal), 2
         ) + round(float(order.tax_paid), 2)
+        order_dict = order.to_dict()
+        assert (
+            order_dict["order_total"] == order_dict["subtotal"] + order_dict["tax_paid"]
+        )


### PR DESCRIPTION
There has been an issue I've chased down for a minute where penny off rounding errors show up in the `orders` data. Because of rounding issues I've changed the math for how `order_total` is calculated to force correctness. I added tests yesterday that _should_ catch this error but don't. Still need to investigate further but this will fix this longstanding issue regardless for the time being.

It also gets rid of the dependency on `pandas` and uses Python's built-in `csv` module for writing the data.