### PR TITLE
feat(generate tweets)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,8 +4,8 @@ iniconfig==2.0.0
     # via pytest
 packaging==24.0
     # via pytest
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 pytest==8.1.1
-ruff==0.3.5
-setuptools==69.2.0
+ruff==0.4.2
+setuptools==69.5.1

--- a/jafgen/curves.py
+++ b/jafgen/curves.py
@@ -67,7 +67,7 @@ class GrowthCurve(Curve):
 
 
 class Day(object):
-    EPOCH = datetime.datetime(year=2016, month=9, day=1)
+    EPOCH = datetime.datetime(year=2018, month=9, day=1)
     SEASONAL_MONTHLY_CURVE = AnnualCurve()
     WEEKEND_CURVE = WeekendCurve()
     GROWTH_CURVE = GrowthCurve()

--- a/jafgen/customers/order.py
+++ b/jafgen/customers/order.py
@@ -5,24 +5,24 @@ from jafgen.customers.order_item import OrderItem
 
 
 class Order(object):
-    def __init__(self, customer, items, store, day):
+    def __init__(self, customer, items, store, order_time):
         self.order_id = str(uuid.uuid4())
         self.customer = customer
         self.items = [OrderItem(self.order_id, item) for item in items]
         self.store = store
-        self.day = day
+        self.order_time = order_time
         self.subtotal = sum(i.item.price for i in self.items)
         self.tax_paid = store.tax_rate * self.subtotal
         self.order_total = self.subtotal + self.tax_paid
 
     def __str__(self):
-        return f"{self.customer.name} bought {str(self.items)} at {self.day}"
+        return f"{self.customer.name} bought {str(self.items)} at {self.order_time}"
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": str(self.order_id),
             "customer": str(self.customer.customer_id),
-            "ordered_at": str(self.day.date.isoformat()),
+            "ordered_at": str(self.order_time.date.isoformat()),
             "store_id": str(self.store.store_id),
             "subtotal": int(self.subtotal * 100),
             "tax_paid": int(self.tax_paid * 100),

--- a/jafgen/customers/tweet.py
+++ b/jafgen/customers/tweet.py
@@ -4,16 +4,28 @@ import uuid
 
 class Tweet:
     def __init__(self, customer, tweet_time, order) -> None:
-        if len(order.items) == 1:
-            items = f"Ordered a {order.items[0].item.name}"
-        elif len(order.items) == 2:
-            items = (
-                f"Ordered a {order.items[0].item.name} and a {order.items[1].item.name}"
-            )
+        self.uuid = str(uuid.uuid4())
+        self.tweeted_at = tweet_time
+        self.customer = customer
+        self.order = order
+        self.content = self.construct_tweet()
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.uuid,
+            "user_id": self.customer.customer_id,
+            "tweeted_at": str(self.tweeted_at.isoformat()),
+            "content": self.content,
+        }
+
+    def construct_tweet(self) -> str:
+        if len(self.order.items) == 1:
+            items_sentence = f"Ordered a {self.order.items[0].item.name}"
+        elif len(self.order.items) == 2:
+            items_sentence = f"Ordered a {self.order.items[0].item.name} and a {self.order.items[1].item.name}"
         else:
-            items = f"Ordered a {', a '.join(item.item.name for item in order.items[:-1])}, and a {order.items[-1].item.name}"
-        self.vibes = random.choice(["good", "bad", "neutral"])
-        if self.vibes == "good":
+            items_sentence = f"Ordered a {', a '.join(item.item.name for item in self.order.items[:-1])}, and a {self.order.items[-1].item.name}"
+        if self.customer.fan_level > 3:
             adjective = random.choice(
                 [
                     "the best",
@@ -25,8 +37,8 @@ class Tweet:
                     "my favorite",
                 ]
             )
-            self.content = f"Jaffles from the Jaffle Shop are {adjective}! {items}."
-        elif self.vibes == "bad":
+            return f"Jaffles from the Jaffle Shop are {adjective}! {items_sentence}."
+        elif self.customer.fan_level < 3:
             adjective = random.choice(
                 [
                     "terrible",
@@ -38,7 +50,7 @@ class Tweet:
                     "my least favorite",
                 ]
             )
-            self.content = f"Jaffle Shop again. {items}. This place is {adjective}."
+            return f"Jaffle Shop again. {items_sentence}. This place is {adjective}."
         else:
             adjective = random.choice(
                 [
@@ -52,16 +64,4 @@ class Tweet:
                     "just meh",
                 ]
             )
-            self.content = f"Jaffle shop is {adjective}. {items}."
-
-        self.uuid = str(uuid.uuid4())
-        self.tweeted_at = tweet_time
-        self.user_id = customer.customer_id
-
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "id": self.uuid,
-            "user_id": self.user_id,
-            "tweeted_at": str(self.tweeted_at.date.isoformat()),
-            "content": self.content,
-        }
+            return f"Jaffle shop is {adjective}. {items_sentence}."

--- a/jafgen/customers/tweet.py
+++ b/jafgen/customers/tweet.py
@@ -1,0 +1,67 @@
+import random
+import uuid
+
+
+class Tweet:
+    def __init__(self, customer, tweet_time, order) -> None:
+        if len(order.items) == 1:
+            items = f"Ordered a {order.items[0].item.name}"
+        elif len(order.items) == 2:
+            items = (
+                f"Ordered a {order.items[0].item.name} and a {order.items[1].item.name}"
+            )
+        else:
+            items = f"Ordered a {', a '.join(item.item.name for item in order.items[:-1])}, and a {order.items[-1].item.name}"
+        self.vibes = random.choice(["good", "bad", "neutral"])
+        if self.vibes == "good":
+            adjective = random.choice(
+                [
+                    "the best",
+                    "awesome",
+                    "delicious",
+                    "amazing",
+                    "fantastic",
+                    "sooo gooood",
+                    "my favorite",
+                ]
+            )
+            self.content = f"Jaffles from the Jaffle Shop are {adjective}! {items}."
+        elif self.vibes == "bad":
+            adjective = random.choice(
+                [
+                    "terrible",
+                    "the worst",
+                    "awful",
+                    "disgusting",
+                    "gross",
+                    "inedible",
+                    "my least favorite",
+                ]
+            )
+            self.content = f"Jaffle Shop again. {items}. This place is {adjective}."
+        else:
+            adjective = random.choice(
+                [
+                    "okay",
+                    "fine",
+                    "alright",
+                    "average",
+                    "pretty decent",
+                    "solid",
+                    "not bad",
+                    "just meh",
+                ]
+            )
+            self.content = f"Jaffle shop is {adjective}. {items}."
+
+        self.uuid = str(uuid.uuid4())
+        self.tweeted_at = tweet_time
+        self.user_id = customer.customer_id
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.uuid,
+            "user_id": self.user_id,
+            "tweeted_at": str(self.tweeted_at.date.isoformat()),
+            "content": self.content,
+        }

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -12,7 +12,7 @@ from jafgen.stores.store import Store
 
 T_7AM = 60 * 7
 T_8AM = 60 * 8
-T_2PM = 60 * 14
+T_3PM = 60 * 15
 T_8PM = 60 * 20
 
 
@@ -87,7 +87,7 @@ class Simulation(object):
                     base_popularity=popularity,
                     hours_of_operation=HoursOfOperation(
                         weekday_range=(T_7AM, T_8PM),
-                        weekend_range=(T_8AM, T_2PM),
+                        weekend_range=(T_8AM, T_3PM),
                     ),
                     opened_date=Day(opened_date),
                     tax_rate=tax,

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -98,6 +98,7 @@ class Simulation(object):
 
         self.customers = {}
         self.orders = []
+        self.tweets = []
         self.sim_days = 365 * self.years
 
     def run_simulation(self):
@@ -106,10 +107,13 @@ class Simulation(object):
         ):
             for market in self.markets:
                 day = Day(i)
-                for order in (o for o in market.sim_day(day) if o is not None):
-                    self.orders.append(order)
-                    if order.customer.customer_id not in self.customers:
-                        self.customers[order.customer.customer_id] = order.customer
+                for result in market.sim_day(day):
+                    if result is not None and all(val is not None for val in result):
+                        order, tweet = result
+                        self.orders.append(order)
+                        self.tweets.append(tweet)
+                        if order.customer.customer_id not in self.customers:
+                            self.customers[order.customer.customer_id] = order.customer
 
     def save_results(self) -> None:
         stock: Stock = Stock()
@@ -121,6 +125,7 @@ class Simulation(object):
             "stores": [market.store.to_dict() for market in self.markets],
             "supplies": stock.to_dict(),
             "products": inventory.to_dict(),
+            "tweets": [tweet.to_dict() for tweet in self.tweets],
         }
 
         if not os.path.exists("./jaffle-data"):

--- a/jafgen/stores/market.py
+++ b/jafgen/stores/market.py
@@ -58,5 +58,5 @@ class Market(object):
             self.active_customers.append(customer)
 
         for customer in self.active_customers:
-            order = customer.sim_day(day)
-            yield order
+            order, tweet = customer.sim_day(day)
+            yield order, tweet

--- a/tests/test_order_totals.py
+++ b/tests/test_order_totals.py
@@ -21,7 +21,7 @@ def test_order_totals():
                     inventory.get_food()[0],
                 ],
                 store=store,
-                day=Day(date_index=i),
+                order_time=Day(date_index=i),
             )
         )
         orders.append(
@@ -33,7 +33,7 @@ def test_order_totals():
                     inventory.get_food()[0],
                 ],
                 store=store,
-                day=Day(date_index=i),
+                order_time=Day(date_index=i),
             )
         )
         orders.append(
@@ -45,7 +45,7 @@ def test_order_totals():
                     inventory.get_food()[0],
                 ],
                 store=store,
-                day=Day(date_index=i),
+                order_time=Day(date_index=i),
             )
         )
     for order in orders:

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,0 +1,51 @@
+import datetime
+from jafgen.stores.store import Store
+from jafgen.customers.customers import (
+    RemoteWorker,
+    BrunchCrowd,
+    HealthNut,
+    Commuter,
+    Casuals,
+    Student,
+)
+from jafgen.curves import Day
+from jafgen.simulation import HoursOfOperation
+
+T_7AM = 60 * 7
+T_8AM = 60 * 8
+T_3PM = 60 * 15
+T_8PM = 60 * 20
+
+
+def test_tweets():
+    """Test that tweets only come after orders and in the range of 20 minutes after."""
+
+    store = Store(
+        str(1),
+        "Testylvania",
+        0.85,
+        HoursOfOperation(
+            weekday_range=(T_7AM, T_8PM),
+            weekend_range=(T_8AM, T_3PM),
+        ),
+        0,
+        0.0659123,
+    )
+    customers = []
+    personas = [RemoteWorker, BrunchCrowd, HealthNut, Commuter, Casuals, Student]
+    for i in range(100):
+        customers.append(personas[i % len(personas)](store))
+
+    for i in range(100):
+        day = Day(i)
+        for customer in customers:
+            order, tweet = customer.sim_day(day)
+            if tweet:
+                assert tweet.customer == customer
+                assert tweet.order == order
+                assert (
+                    tweet.tweeted_at
+                    <= tweet.order.order_time.date + datetime.timedelta(minutes=20)
+                )
+            if not order:
+                assert not tweet


### PR DESCRIPTION
Adds `Tweet` type to `jafgen`. The way this is intended to work is:
1. a random time window between 0 and 20 minutes after the order, a tweet is potentially generated
2. different Personas have different fixed tweet propensities. These are simpler than the buying propensities because they're already dependent on the more complex behavior of the buying propensities, so they're just fixed probabilities. Students and Brunch Crowd are very tweet-happy, Commuters very much not so.
3. Tweets are generated via simple rules that combine the items purchased with a randomly assigned `fan_level` Customers get upon instantiation, and some random selection of adjectives that correspond to the fan level (high fan levels select from positive adjectives, medium from neutral, low from negative).

This should enable some fun analysis like determining cohorts of fans via sentiment analysis.