### PR TITLE
Changing the | operator to typing.Union

### DIFF
--- a/jafgen/curves.py
+++ b/jafgen/curves.py
@@ -4,8 +4,9 @@ from abc import ABC, abstractmethod
 import numpy as np
 import numpy.typing as npt
 from typing_extensions import override
+from typing import Union
 
-NumberArr = npt.NDArray[np.float64] | npt.NDArray[np.int32]
+NumberArr = Union[npt.NDArray[np.float64], npt.NDArray[np.int32]]
 
 
 
@@ -73,4 +74,3 @@ class GrowthCurve(Curve):
     def Expr(self, x: float) -> float:
         # ~ aim for ~20% growth/year
         return 1 + (x / 12) * 0.2
-

--- a/jafgen/customers/customers.py
+++ b/jafgen/customers/customers.py
@@ -1,7 +1,7 @@
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, NewType
+from typing import Any, NewType, Union
 
 import numpy as np
 from faker import Faker
@@ -45,7 +45,7 @@ class Customer(ABC):
     def p_tweet(self, day: Day) -> float:
         return self.p_tweet_persona(day)
 
-    def get_order(self, day: Day) -> Order | None:
+    def get_order(self, day: Day) -> Union[Order, None]:
         items = self.get_order_items(day)
 
         order_minute = self.get_order_minute(day)

--- a/jafgen/stores/market.py
+++ b/jafgen/stores/market.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, Union
 
 import numpy as np
 from faker import Faker
@@ -44,7 +44,7 @@ class Market:
 
         fake.random.shuffle(self.addressable_customers)
 
-    def sim_day(self, day: Day) -> Iterator[tuple[Order | None, Tweet | None]]:
+    def sim_day(self, day: Day) -> Iterator[tuple[Union[Order, None], Union[Tweet, None]]]:
         days_since_open = self.store.days_since_open(day)
         if days_since_open < 0:
             yield None, None

--- a/jafgen/stores/supply.py
+++ b/jafgen/stores/supply.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import NewType
+from typing import NewType, Union
 
 SupplyId = NewType("SupplyId", str)
 StorageKeepingUnit = NewType("StorageKeepingUnit", str)
@@ -18,7 +18,7 @@ class Supply:
     def __repr__(self):
         return self.__str__()
 
-    def to_dict(self, sku: StorageKeepingUnit) -> dict[str, str | int]:
+    def to_dict(self, sku: StorageKeepingUnit) -> dict[str, Union[str, int]]:
         return {
             "id": str(self.id),
             "name": str(self.name),

--- a/jafgen/time.py
+++ b/jafgen/time.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterator
+from typing import Iterator, Union
 
 from jafgen.curves import AnnualCurve, GrowthCurve, WeekendCurve
 
@@ -27,7 +27,7 @@ def time_from_total_minutes(mins: int) -> dt.time:
     return dt.time(hour=mins // 60, minute=mins % 60)
 
 
-def total_minutes_elapsed(t: dt.time | dt.timedelta) -> int:
+def total_minutes_elapsed(t: Union[dt.time, dt.timedelta]) -> int:
     """Get the total minutes that passed since midnight for a time or timedelta."""
     if isinstance(t, dt.time):
         return t.second * 60 + t.minute
@@ -139,4 +139,3 @@ class WeekHoursOfOperation:
 
     def iter_minutes(self, day: Day) -> Iterator[int]:
         yield from self._get_todays_schedule(day).iter_minutes()
-


### PR DESCRIPTION
When I run jafgen on my machine I get this error in some of the .py files

>   File "/Users/brunosouzadelima/dbt/venv/lib/python3.9/site-packages/jafgen-0.4.14-py3.9.egg/jafgen/stores/supply.py", line 21, in Supply
TypeError: unsupported operand type(s) for |: 'type' and 'type'

To Fix this, instead of using the bitwise OR operator, I changed it to Python's built-in typing.Union to represent the possibility of multiple types within the type hints.

It fixed the problem for me.