### PR TITLE
fix: output lowercase value of ItemType

### DIFF
--- a/jafgen/stores/item.py
+++ b/jafgen/stores/item.py
@@ -9,6 +9,9 @@ class ItemType(str, Enum):
     JAFFLE = "JAFFLE"
     BEVERAGE = "BEVERAGE"
 
+    def __str__(self):
+        return str(self.value).lower()
+
 
 @dataclass(frozen=True)
 class Item:


### PR DESCRIPTION
Currently it outputs ItemType.JAFFLE or ItemType.BEVERAGE, changing that to the lowecase values themselves.