### PR TITLE
Fixed small issue for low number of days in the simulation

### DIFF
--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -93,9 +93,8 @@ class Simulation:
         for entity, data in track(
             entities.items(), description="🚚 Delivering jaffles..."
         ):
-            with open(
-                f"./jaffle-data/{self.prefix}_{entity}.csv", "w", newline=""
-            ) as file:
-                writer = csv.DictWriter(file, fieldnames=data[0].keys())
+            if data:
+                file = f"./jaffle-data/{self.prefix}_{entity}.csv"
+                writer = csv.DictWriter(open(file, "w", newline=""), fieldnames=data[0].keys())
                 writer.writeheader()
                 writer.writerows(data)


### PR DESCRIPTION
When you do a small number of days (<5). There is a possibility that the data for the entities that are generated is empty. /

This resulted in an empty list error.

This fix makes sure we are able to handle empty lists. 