### PR TITLE
Fix order items data

### DIFF
--- a/jafgen/customers/order.py
+++ b/jafgen/customers/order.py
@@ -1,42 +1,53 @@
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, NewType
+from typing import Any, List, NewType
 
 from faker import Faker
 
-import jafgen.customers.customers as customer
-from jafgen.stores.item import Item
+import jafgen.customers.customer as customer
+from jafgen.stores.product import Product
 from jafgen.stores.store import Store
 from jafgen.time import Day
 
 fake = Faker()
 
 OrderId = NewType("OrderId", uuid.UUID)
+OrderItemId = NewType("OrderItemId", uuid.UUID)
+
+
+@dataclass
+class OrderItem:
+    product: Product
+    quantity: int = 1
+    id: OrderItemId = field(
+        default_factory=lambda: OrderItemId(uuid.UUID(fake.uuid4()))
+    )
+
 
 @dataclass
 class Order:
     customer: "customer.Customer"
     day: Day
     store: Store
-    items: list[Item]
-    id: OrderId = field(default_factory=lambda: OrderId(fake.uuid4()))
+    order_items: list[OrderItem]
+    id: OrderId = field(default_factory=lambda: OrderId(uuid.UUID(fake.uuid4())))
 
     subtotal: float = field(init=False)
     tax_paid: float = field(init=False)
     total: float = field(init=False)
 
     def __post_init__(self) -> None:
-        self.subtotal = sum(i.price for i in self.items)
+        self.subtotal = sum(i.product.price * i.quantity for i in self.order_items)
         self.tax_paid = self.store.tax_rate * self.subtotal
         self.total = self.subtotal + self.tax_paid
 
     def __str__(self):
-        return f"{self.customer.name} bought {str(self.items)} at {self.day}"
+        return f"{self.customer.name} bought {str(self.order_items)} at {self.day}"
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": str(self.id),
-            "customer": str(self.customer.id),
+            "customer_id": str(self.customer.id),
             "ordered_at": str(self.day.date.isoformat()),
             "store_id": str(self.store.id),
             "subtotal": int(self.subtotal * 100),
@@ -47,5 +58,13 @@ class Order:
             "order_total": int(int(self.subtotal * 100) + int(self.tax_paid * 100)),
         }
 
-    def items_to_dict(self) -> list[dict[str, Any]]:
-        return [item.to_dict() for item in self.items]
+    def order_items_to_dict(self) -> List[dict[str, Any]]:
+        return [
+            {
+                "id": str(order_item.id),
+                "order_id": str(self.id),
+                "sku": str(order_item.product.sku),
+                "quantity": order_item.quantity,
+            }
+            for order_item in self.order_items
+        ]

--- a/jafgen/customers/tweet.py
+++ b/jafgen/customers/tweet.py
@@ -4,7 +4,7 @@ from typing import NewType
 
 from faker import Faker
 
-import jafgen.customers.customers as customer
+import jafgen.customers.customer as customer
 from jafgen.customers.order import Order
 from jafgen.time import Day
 
@@ -18,7 +18,7 @@ class Tweet:
     day: Day
     customer: "customer.Customer"
     order: Order
-    id: TweetId = field(default_factory=lambda: TweetId(fake.uuid4()))
+    id: TweetId = field(default_factory=lambda: TweetId(uuid.UUID(fake.uuid4())))
     content: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -33,12 +33,12 @@ class Tweet:
         }
 
     def _construct_tweet(self) -> str:
-        if len(self.order.items) == 1:
-            items_sentence = f"Ordered a {self.order.items[0].name}"
-        elif len(self.order.items) == 2:
-            items_sentence = f"Ordered a {self.order.items[0].name} and a {self.order.items[1].name}"
+        if len(self.order.order_items) == 1:
+            items_sentence = f"Ordered a {self.order.order_items[0].product.name}"
+        elif len(self.order.order_items) == 2:
+            items_sentence = f"Ordered a {self.order.order_items[0].product.name} and a {self.order.order_items[1].product.name}"
         else:
-            items_sentence = f"Ordered a {', a '.join(item.name for item in self.order.items[:-1])}, and a {self.order.items[-1].name}"
+            items_sentence = f"Ordered a {', a '.join(item.product.name for item in self.order.order_items[:-1])}, and a {self.order.order_items[-1].product.name}"
         if self.customer.fan_level > 3:
             adjective = fake.random.choice(
                 [

--- a/jafgen/jaffle-shop-generator.code-workspace
+++ b/jafgen/jaffle-shop-generator.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		}
+    ],
+    "settings": {}
+}

--- a/jafgen/simulation.py
+++ b/jafgen/simulation.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from rich.progress import track
 
-from jafgen.customers.customers import Customer, CustomerId
+from jafgen.customers.customer import Customer, CustomerId
 from jafgen.customers.order import Order
 from jafgen.customers.tweet import Tweet
 from jafgen.stores.inventory import Inventory
@@ -22,6 +22,7 @@ T_7AM = time_from_total_minutes(60 * 7)
 T_8AM = time_from_total_minutes(60 * 8)
 T_3PM = time_from_total_minutes(60 * 15)
 T_8PM = time_from_total_minutes(60 * 20)
+
 
 class Simulation:
     def __init__(self, years: int, days: int, prefix: str):
@@ -63,7 +64,8 @@ class Simulation:
 
     def run_simulation(self):
         for i in track(
-            range(self.sim_days), description=f"🥪 Pressing {self.sim_days} days of fresh jaffles..."
+            range(self.sim_days),
+            description=f"🥪 Pressing {self.sim_days} days of fresh jaffles...",
         ):
             for market in self.markets:
                 day = Day(i)
@@ -81,7 +83,11 @@ class Simulation:
         entities: dict[str, list[dict[str, Any]]] = {
             "customers": [customer.to_dict() for customer in self.customers.values()],
             "orders": [order.to_dict() for order in self.orders],
-            "items": [item.to_dict() for order in self.orders for item in order.items],
+            "order_items": [
+                item_dict
+                for order in self.orders
+                for item_dict in order.order_items_to_dict()
+            ],
             "stores": [market.store.to_dict() for market in self.markets],
             "supplies": stock.to_dict(),
             "products": inventory.to_dict(),
@@ -95,6 +101,8 @@ class Simulation:
         ):
             if data:
                 file = f"./jaffle-data/{self.prefix}_{entity}.csv"
-                writer = csv.DictWriter(open(file, "w", newline=""), fieldnames=data[0].keys())
+                writer = csv.DictWriter(
+                    open(file, "w", newline=""), fieldnames=data[0].keys()
+                )
                 writer.writeheader()
                 writer.writerows(data)

--- a/jafgen/stores/inventory.py
+++ b/jafgen/stores/inventory.py
@@ -2,25 +2,25 @@ from typing import Any
 
 from faker import Faker
 
-from jafgen.stores.item import Item, ItemType
+from jafgen.stores.product import Product, ProductType
 from jafgen.stores.supply import StorageKeepingUnit as SKU
 
 fake = Faker()
 
 
 class Inventory:
-    inventory: dict[ItemType, list[Item]] = {}
+    inventory: dict[ProductType, list[Product]] = {}
 
     @classmethod
-    def update(cls, inventory_list: list[Item]):
-        cls.inventory[ItemType.JAFFLE]= []
-        cls.inventory[ItemType.BEVERAGE] = []
+    def update(cls, inventory_list: list[Product]):
+        cls.inventory[ProductType.JAFFLE] = []
+        cls.inventory[ProductType.BEVERAGE] = []
         for item in inventory_list:
             cls.inventory[item.type].append(item)
 
     @classmethod
-    def get_item_type(cls, type: ItemType, count: int = 1):
-        return [fake.random.choice(cls.inventory[type])for _ in range(count)]
+    def get_item_type(cls, type: ProductType, count: int = 1):
+        return [fake.random.choice(cls.inventory[type]) for _ in range(count)]
 
     @classmethod
     def to_dict(cls) -> list[dict[str, Any]]:
@@ -32,72 +32,74 @@ class Inventory:
 
 Inventory.update(
     [
-        Item(
+        Product(
             sku=SKU("JAF-001"),
             name="nutellaphone who dis?",
             description="nutella and banana jaffle",
-            type=ItemType.JAFFLE,
+            type=ProductType.JAFFLE,
             price=11,
         ),
-        Item(
+        Product(
             sku=SKU("JAF-002"),
             name="doctor stew",
             description="house-made beef stew jaffle",
-            type=ItemType.JAFFLE,
+            type=ProductType.JAFFLE,
             price=11,
         ),
-        Item(
+        Product(
             sku=SKU("JAF-003"),
             name="the krautback",
             description="lamb and pork bratwurst with house-pickled cabbage sauerkraut and mustard",
-            type=ItemType.JAFFLE,
+            type=ProductType.JAFFLE,
             price=12,
         ),
-        Item(
+        Product(
             sku=SKU("JAF-004"),
             name="flame impala",
             description="pulled pork and pineapple al pastor marinated in ghost pepper sauce, kevin parker's favorite! ",
-            type=ItemType.JAFFLE,
+            type=ProductType.JAFFLE,
             price=14,
         ),
-        Item(
-            sku=SKU("JAF-005"), name="mel-bun", description="melon and minced beef bao, in a jaffle, savory and sweet",
-            type=ItemType.JAFFLE,
+        Product(
+            sku=SKU("JAF-005"),
+            name="mel-bun",
+            description="melon and minced beef bao, in a jaffle, savory and sweet",
+            type=ProductType.JAFFLE,
             price=12,
         ),
-        Item(
+        Product(
             sku=SKU("BEV-001"),
             name="tangaroo",
             description="mango and tangerine smoothie",
-            type=ItemType.BEVERAGE,
+            type=ProductType.BEVERAGE,
             price=6,
         ),
-        Item(
+        Product(
             sku=SKU("BEV-002"),
             name="chai and mighty",
             description="oatmilk chai latte with protein boost",
-            type=ItemType.BEVERAGE,
+            type=ProductType.BEVERAGE,
             price=5,
         ),
-        Item(
+        Product(
             sku=SKU("BEV-003"),
             name="vanilla ice",
             description="iced coffee with house-made french vanilla syrup",
-            type=ItemType.BEVERAGE,
+            type=ProductType.BEVERAGE,
             price=6,
         ),
-        Item(
+        Product(
             sku=SKU("BEV-004"),
             name="for richer or pourover ",
             description="daily selection of single estate beans for a delicious hot pourover",
-            type=ItemType.BEVERAGE,
+            type=ProductType.BEVERAGE,
             price=7,
         ),
-        Item(
+        Product(
             sku=SKU("BEV-005"),
             name="adele-ade",
             description="a kiwi and lime agua fresca, hello from the other side of thirst",
-            type=ItemType.BEVERAGE,
+            type=ProductType.BEVERAGE,
             price=4,
         ),
     ]

--- a/jafgen/stores/market.py
+++ b/jafgen/stores/market.py
@@ -3,7 +3,7 @@ from typing import Iterator
 import numpy as np
 from faker import Faker
 
-from jafgen.customers.customers import (
+from jafgen.customers.customer import (
     BrunchCrowd,
     Casuals,
     Commuter,
@@ -19,6 +19,7 @@ from jafgen.time import Day
 
 fake = Faker()
 
+
 class Market:
     PersonaMix = [
         (Commuter, 0.25),
@@ -29,7 +30,9 @@ class Market:
         (HealthNut, 0.1),
     ]
 
-    def __init__(self, store: Store, num_customers: int, days_to_penetration: int = 365):
+    def __init__(
+        self, store: Store, num_customers: int, days_to_penetration: int = 365
+    ):
         self.store = store
         self.num_customers = num_customers
         self.days_to_penetration = days_to_penetration

--- a/jafgen/stores/product.py
+++ b/jafgen/stores/product.py
@@ -5,17 +5,17 @@ from typing import Any
 from jafgen.stores.supply import StorageKeepingUnit
 
 
-class ItemType(str, Enum):
+class ProductType(str, Enum):
     JAFFLE = "JAFFLE"
     BEVERAGE = "BEVERAGE"
 
 
 @dataclass(frozen=True)
-class Item:
+class Product:
     sku: StorageKeepingUnit
     name: str
     description: str
-    type: ItemType
+    type: ProductType
     price: float
 
     def __str__(self):
@@ -28,7 +28,7 @@ class Item:
         return {
             "sku": self.sku,
             "name": str(self.name),
-            "type": str(self.type),
+            "type": str(self.type.value),
             "price": int(self.price * 100),
             "description": str(self.description),
         }

--- a/jafgen/stores/store.py
+++ b/jafgen/stores/store.py
@@ -11,6 +11,7 @@ fake = Faker()
 
 StoreId = NewType("StoreId", uuid.UUID)
 
+
 @dataclass(frozen=True)
 class Store:
     name: str
@@ -18,7 +19,7 @@ class Store:
     hours_of_operation: WeekHoursOfOperation
     opened_day: Day
     tax_rate: float
-    id: StoreId = field(default_factory=lambda: StoreId(fake.uuid4()))
+    id: StoreId = field(default_factory=lambda: StoreId(uuid.UUID(fake.uuid4())))
 
     def p_buy(self, day: Day) -> float:
         return self.base_popularity * day.get_effect()

--- a/tests/test_days.py
+++ b/tests/test_days.py
@@ -2,5 +2,5 @@ from jafgen.simulation import Simulation
 
 
 def test_year_length():
-    sim = Simulation(2, "raw")
+    sim = Simulation(2, 0, "raw")
     assert sim.sim_days == 730

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,26 +1,26 @@
 from jafgen.stores.inventory import Inventory
-from jafgen.stores.item import ItemType
+from jafgen.stores.product import ProductType
 from jafgen.stores.stock import Stock
 from jafgen.stores.supply import Supply
 
 
 def test_stock_and_inventory_equal():
     """Ensure Stock and Inventory have an equal number of items"""
-    assert len(Stock.stock) == len(Inventory.inventory[ItemType.JAFFLE]) + len(
-        Inventory.inventory[ItemType.BEVERAGE]
+    assert len(Stock.stock) == len(Inventory.inventory[ProductType.JAFFLE]) + len(
+        Inventory.inventory[ProductType.BEVERAGE]
     )
 
 
 def test_all_inventory_beverages_are_beverages():
     """Ensure all the items in inventory.beverage are of type beverage"""
-    for item in Inventory.inventory[ItemType.BEVERAGE]:
-        assert item.type == ItemType.BEVERAGE
+    for item in Inventory.inventory[ProductType.BEVERAGE]:
+        assert item.type == ProductType.BEVERAGE
 
 
 def test_all_inventory_jaffles_are_jaffles():
     """Ensure all the items in inventory.jaffle are of type jaffle"""
-    for item in Inventory.inventory[ItemType.JAFFLE]:
-        assert item.type == ItemType.JAFFLE
+    for item in Inventory.inventory[ProductType.JAFFLE]:
+        assert item.type == ProductType.JAFFLE
 
 
 def test_inventory_stock_all_has_supplies():

--- a/tests/test_order_totals.py
+++ b/tests/test_order_totals.py
@@ -1,9 +1,9 @@
-from jafgen.time import Day
-from jafgen.customers.customers import Customer, BrunchCrowd, RemoteWorker, Student
-from jafgen.customers.order import Order
-from jafgen.stores.item import ItemType
+from jafgen.customers.customer import BrunchCrowd, Customer, RemoteWorker, Student
+from jafgen.customers.order import Order, OrderItem
 from jafgen.stores.inventory import Inventory
+from jafgen.stores.product import ProductType
 from jafgen.stores.store import Store
+from jafgen.time import Day
 
 
 def test_order_totals(default_store: Store):
@@ -13,12 +13,13 @@ def test_order_totals(default_store: Store):
     customer_types: list[type[Customer]] = [RemoteWorker, BrunchCrowd, Student]
     for i in range(1000):
         for CustType in customer_types:
+            food = inventory.get_item_type(ProductType.JAFFLE, 2)
+            beverage = inventory.get_item_type(ProductType.BEVERAGE, 1)
+            all_items = food + beverage
             orders.append(
                 Order(
                     customer=CustType(store=default_store),
-                    items=
-                        inventory.get_item_type(ItemType.JAFFLE, 2) +
-                        inventory.get_item_type(ItemType.BEVERAGE, 1),
+                    order_items=[OrderItem(product=item) for item in all_items],
                     store=default_store,
                     day=Day(date_index=i),
                 )
@@ -27,15 +28,15 @@ def test_order_totals(default_store: Store):
     for order in orders:
         assert (
             order.subtotal
-            == order.items[0].price
-            + order.items[1].price
-            + order.items[2].price
+            == order.order_items[0].product.price
+            + order.order_items[1].product.price
+            + order.order_items[2].product.price
         )
         assert order.tax_paid == order.subtotal * order.store.tax_rate
         assert order.total == order.subtotal + order.tax_paid
-        assert round(float(order.total), 2) == round(
-            float(order.subtotal), 2
-        ) + round(float(order.tax_paid), 2)
+        assert round(float(order.total), 2) == round(float(order.subtotal), 2) + round(
+            float(order.tax_paid), 2
+        )
         order_dict = order.to_dict()
         assert (
             order_dict["order_total"] == order_dict["subtotal"] + order_dict["tax_paid"]

--- a/tests/test_tweets.py
+++ b/tests/test_tweets.py
@@ -1,5 +1,4 @@
-from jafgen.time import Day
-from jafgen.customers.customers import (
+from jafgen.customers.customer import (
     BrunchCrowd,
     Casuals,
     Commuter,
@@ -9,6 +8,7 @@ from jafgen.customers.customers import (
     Student,
 )
 from jafgen.stores.store import Store
+from jafgen.time import Day
 
 
 def test_tweets(default_store: Store):
@@ -27,7 +27,9 @@ def test_tweets(default_store: Store):
                 assert tweet.order == order
                 assert (
                     tweet.day.date
-                    <= tweet.order.day.at_minute(tweet.order.day.total_minutes + 20).date
+                    <= tweet.order.day.at_minute(
+                        tweet.order.day.total_minutes + 20
+                    ).date
                 )
             if not order:
                 assert not tweet


### PR DESCRIPTION
Hey! Great project!

Running `jafgen` off the latest commit doesn't return order item data as expected - instead the data produced are copies of the different products.

I've reintroduced order items throughout with some slight changes to the codebase:

- Added `OrderItem` in `order.py` and changed the `get_order_items` return type for each of the customer personas.
- Order items now have a `quantity` field, indicating a customer can order multiples of a particular product.
- I've renamed `Item` to `Product` throughout to distinguish between a product-item and an order-item.