### PR TITLE
Changing the start date something more current

### DIFF
--- a/jafgen/time.py
+++ b/jafgen/time.py
@@ -59,7 +59,7 @@ class Season(str, Enum):
 
 @dataclass(init=False)
 class Day:
-    EPOCH = dt.datetime(year=2018, month=9, day=1)
+    EPOCH = dt.datetime(year=2023, month=9, day=1)
     SEASONAL_MONTHLY_CURVE = AnnualCurve()
     WEEKEND_CURVE = WeekendCurve()
     GROWTH_CURVE = GrowthCurve()


### PR DESCRIPTION
This updates the start date for the data generated to something a little more recent - 2023 instead of 2018 - so the user doesn't have to generate 7 years of data to reach a current date. 